### PR TITLE
 Restrict maximum velocity using waypoints, not hard-coded value #5 -…

### DIFF
--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -1,14 +1,16 @@
 #!/usr/bin/env python
 
-import copy
-import math
-
-import numpy as np
 import rospy
-import tf
-from geometry_msgs.msg import PoseStamped
+from geometry_msgs.msg import PoseStamped, Point, TwistStamped
+from styx_msgs.msg import Lane, Waypoint, TrafficLightArray, TrafficLight
 from std_msgs.msg import Int32
-from styx_msgs.msg import Lane
+
+import math
+import numpy as np
+import tf
+import yaml
+import matplotlib.pyplot as plt
+import copy
 
 '''
 This node will publish waypoints from the car's current position to some `x` distance ahead.

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -30,7 +30,6 @@ TODO (for Yousuf and Aaron): Stopline location for each traffic light.
 LOOKAHEAD_WPS = 100 # Number of waypoints we will publish. You can change this number
 
 MAX_DECEL = 5
-MAX_VEL = 10.0
 
 
 class WaypointUpdater(object):
@@ -57,7 +56,7 @@ class WaypointUpdater(object):
 
     def pose_cb(self, msg):
         self.pose = msg.pose
-        if self.wps:
+        if self.wps and self.wps_base:
             next_wp = self.next_waypoint(self.pose.position, self.pose.orientation, self.next_wp)
             self.next_wp = next_wp
             self.publish_final_waypoints(next_wp)
@@ -72,11 +71,10 @@ class WaypointUpdater(object):
         last_wp = next_wp + LOOKAHEAD_WPS
         wps = self.wps[next_wp : last_wp]
         wps_base = self.wps_base[next_wp : last_wp]
-        # inc_vel = (MAX_VEL - curr_vel)/float(last_wp - next_wp)
+        # inc_vel = (self.wps_base[next_wp-1].twist.twist.linear.x - curr_vel)/float(last_wp - next_wp)
         inc_vel = 1.0
         for i, w in enumerate(wps):
             w.twist.twist.linear.x = curr_vel + inc_vel * (i+1)
-            if w.twist.twist.linear.x > MAX_VEL: w.twist.twist.linear.x = MAX_VEL
             w.twist.twist.linear.x = min(w.twist.twist.linear.x, wps_base[i].twist.twist.linear.x)
         sample = [wps[i].twist.twist.linear.x for i in range(0, 20, 2)]
         rospy.loginfo("wp init cruise %s %s", inc_vel, sample)


### PR DESCRIPTION
Replaced hard-coded value with recommended from the original base waypoints.
Example listed in the table below:

Calculated (self.wps) | Recommended (self.wps_base) | Final Value | Comment
--- | --- | --- | ---
10 | 5 | **5** | when plan `cruise_trajectory`
2 | 5 | **2** | when plan `stop_trajectory`